### PR TITLE
Manga adjustements

### DIFF
--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/MangaKog.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/MangaKog.kt
@@ -387,33 +387,37 @@ class MangaExtension: Extension(), KordExKoinComponent {
 
                 val validPpc: Boolean = ppc > 0
 
-                respond {
-                    if (validPpc) try {
-                        val imgURLSource: URL? = arguments.image?.let { URL(it.url) }
-                        val tags = arguments.tags.toTagSet()
+                if (!validPpc) {
+                    respondWithError(
+                        "Especifica la cantidad de páginas por capítulo o valores" +
+                                " en otros argumentos que me permitan computarlo!"
+                    )
+                } else try {
+                    val imgURLSource: URL? = arguments.image?.let { URL(it.url) }
 
-                        val insertedManga = db.addManga(
-                                title = arguments.title,
-                                description = arguments.description,
-                                imgURLSource = imgURLSource,
-                                link = arguments.link,
-                                demographic = arguments.demographic,
-                                volumes = volumes,
-                                pagesPerVolume = ppv,
-                                chapters = chapters,
-                                pagesPerChapter = ppc,
-                                tags = arguments.tags.toTagSet(), // TODO: Make tags be saved in lowercase in db
-                                read = false
-                        )
+                    val insertedManga = db.addManga(
+                        title = arguments.title,
+                        description = arguments.description,
+                        imgURLSource = imgURLSource,
+                        link = arguments.link,
+                        demographic = arguments.demographic,
+                        volumes = volumes,
+                        pagesPerVolume = ppv,
+                        chapters = chapters,
+                        pagesPerChapter = ppc,
+                        tags = arguments.tags.toTagSet(), // TODO: Make tags be saved in lowercase in db
+                        read = false
+                    )
+
+                    respond {
                         content = "Agregado exitosamente."
+
                         embed {
                             mangaView(insertedManga)
                         }
-                    } catch (e: DownloadException) {
-                            content = "Error al agregar."
-                    } else {
-                        content = "**Error**: Especifica la cantidad de páginas por capítulo o valores en otros argumentos que me permitan computarlo!"
                     }
+                } catch (e: DownloadException) {
+                    respondWithError("Error al agregar")
                 }
             }
         }

--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/MangaKog.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/MangaKog.kt
@@ -450,39 +450,36 @@ class MangaExtension: Extension(), KordExKoinComponent {
                     return@action
                 }
 
-                respond {
-                    confirmationDialog(
-                            "¿Confirmas la edición sobre ${currentManga.title}?",
-                            user.asUser(),
-                    ) {
-                        val mangaChanges = with(arguments) {
-                            MangaChanges(
-                                id=id,
-                                title=title,
-                                description=description,
-                                imgURLSource=arguments.image?.let { URL(it.url) },
-                                link=link,
-                                volumes=volumes,
-                                pagesPerVolume=pagesPerVolume,
-                                chapters=chapters,
-                                pagesPerChapter=pagesPerChapter,
-                                demographic=demographic,
-                                tagsToAdd=addTags?.toTagSet(),
-                                tagsToRemove=removeTags?.toTagSet(),
-                                read=null,
-                            )
-                        }
+                requestConfirmation(
+                        "¿Confirmas la edición sobre ${currentManga.title}?",
+                ) {
+                    val mangaChanges = with(arguments) {
+                        MangaChanges(
+                            id=id,
+                            title=title,
+                            description=description,
+                            imgURLSource=arguments.image?.let { URL(it.url) },
+                            link=link,
+                            volumes=volumes,
+                            pagesPerVolume=pagesPerVolume,
+                            chapters=chapters,
+                            pagesPerChapter=pagesPerChapter,
+                            demographic=demographic,
+                            tagsToAdd=addTags?.toTagSet(),
+                            tagsToRemove=removeTags?.toTagSet(),
+                            read=null,
+                        )
+                    }
 
-                        try {
-                            db.updateManga(mangaChanges, *flags.toTypedArray())
-                            kordLogger.info { "${user.id} edited entry #${mangaChanges.id} (${currentManga.title})" }
+                    try {
+                        db.updateManga(mangaChanges, *flags.toTypedArray())
+                        kordLogger.info { "${user.id} edited entry #${mangaChanges.id} (${currentManga.title})" }
 
-                            respondWithChanges(currentManga)
-                        } catch (e: DownloadException) {
-                            kordLogger.trace(e) { "Error downloading a cover from ${currentManga.imgURLSource}" }
+                        respondWithChanges(currentManga)
+                    } catch (e: DownloadException) {
+                        kordLogger.trace(e) { "Error downloading a cover from ${currentManga.imgURLSource}" }
 
-                            respondWithError("Hubo un problema descargando la imagen")
-                        }
+                        respondWithError("Hubo un problema descargando la imagen")
                     }
                 }
             }
@@ -506,16 +503,13 @@ class MangaExtension: Extension(), KordExKoinComponent {
                     return@action
                 }
 
-                respond {
-                    confirmationDialog(
-                        "¿Confirmas la eliminación de **${manga.title}**?",
-                        user.asUser()
-                    ) {
-                        val successfullyDeleted = db.deleteManga(manga.id)
+                requestConfirmation(
+                    "¿Confirmas la eliminación de **${manga.title}**?",
+                ) {
+                    val successfullyDeleted = db.deleteManga(manga.id)
 
-                        if (successfullyDeleted) respondWithSuccess("Eliminado **${manga.title}**")
-                        else respondWithError("No se pudo eliminar ${manga.title}")
-                    }
+                    if (successfullyDeleted) respondWithSuccess("Eliminado **${manga.title}**")
+                    else respondWithError("No se pudo eliminar ${manga.title}")
                 }
             }
         }

--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/MangaKog.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/MangaKog.kt
@@ -392,7 +392,7 @@ class MangaExtension: Extension(), KordExKoinComponent {
                         val imgURLSource: URL? = arguments.image?.let { URL(it.url) }
                         val tags = arguments.tags.toTagSet()
 
-                        val id = db.addManga(
+                        val insertedManga = db.addManga(
                                 title = arguments.title,
                                 description = arguments.description,
                                 imgURLSource = imgURLSource,
@@ -407,20 +407,7 @@ class MangaExtension: Extension(), KordExKoinComponent {
                         )
                         content = "Agregado exitosamente."
                         embed {
-                            // TODO: rewrite this mess! Also,
-                            //  the image used here is EPHEMERAL so
-                            //  we shouldn't rely on it
-                            val a = arguments
-                            mangaView(
-                                MangaWithTagsData(
-                                    MangaData(
-                                        id, a.title, java.time.Instant.now().epochSecond, a.description, imgURLSource,
-                                        a.link, a.demographic, a.volumes, a.pagesPerVolume, a.chapters, a.pagesPerChapter,
-                                        false
-                                    ),
-                                    tags
-                                )
-                            )
+                            mangaView(insertedManga)
                         }
                     } catch (e: DownloadException) {
                             content = "Error al agregar."

--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/MangaKog.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/MangaKog.kt
@@ -344,12 +344,10 @@ class MangaExtension: Extension(), KordExKoinComponent {
                 val mangaList = db.getMangas(*ids).toList()
 
                 when {
-                    mangaList.isEmpty() -> respond {
-                        embed {
-                            title = "Sin resultados"
-                            description = "No se encontró nada similar a lo buscado"
-                        }
-                    }
+                    mangaList.isEmpty() -> respondWithInfo(
+                        "Sin resultados",
+                        "No se encontró nada similar a lo buscado"
+                    )
 
                     mangaList.size == 1 -> respond {
                         embeds.add(EmbedBuilder().mangaView(mangaList.first()))
@@ -439,18 +437,16 @@ class MangaExtension: Extension(), KordExKoinComponent {
                 val somethingChanged = arguments.args.any { it.converter.parsed != null && it.displayName != "id" }
 
                 if (!somethingChanged) {
-                    respond {
-                        content = "No has especificado ningún cambio."
-                    }
+                    respondWithError("No has especificado ningún cambio.")
+
                     return@action
                 }
 
                 val currentManga = db.getManga(arguments.id)
 
                 currentManga ?: run {
-                    respond {
-                        content = "La id ${arguments.id} no pudo ser encontrada"
-                    }
+                    respondWithError("La id ${arguments.id} no pudo ser encontrada")
+
                     return@action
                 }
 
@@ -505,9 +501,8 @@ class MangaExtension: Extension(), KordExKoinComponent {
                 val manga = db.getManga(arguments.id)
 
                 manga ?: run {
-                    respond {
-                        content = "La id ${arguments.id} no pudo ser encontrada"
-                    }
+                    respondWithError("La id ${arguments.id} no pudo ser encontrada")
+
                     return@action
                 }
 
@@ -516,11 +511,10 @@ class MangaExtension: Extension(), KordExKoinComponent {
                         "¿Confirmas la eliminación de **${manga.title}**?",
                         user.asUser()
                     ) {
-                        respond {
-                            db.deleteManga(manga.id)
-                            content = if (db.deleteManga(manga.id)) "Eliminado **${manga.title}**"
-                            else "No se pudo eliminar ${manga.title}."
-                        }
+                        val successfullyDeleted = db.deleteManga(manga.id)
+
+                        if (successfullyDeleted) respondWithSuccess("Eliminado **${manga.title}**")
+                        else respondWithError("No se pudo eliminar ${manga.title}")
                     }
                 }
             }

--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/MangaKog.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/MangaKog.kt
@@ -294,27 +294,21 @@ class MangaExtension: Extension(), KordExKoinComponent {
                 val mangaList = db.searchManga(title, tag, demographic, 15)
 
                 when {
-                    mangaList.isEmpty() -> respond {
-                        embed {
-                            this.title = "Sin resultados"
-                            description = "No se encontró nada similar a lo buscado:\n\n$filterDescription"
+                    mangaList.isEmpty() -> respondWithInfo(
+                        title="Sin resultados",
+                        description="No se encontró nada similar a lo buscado:\n\n$filterDescription"
+                    )
 
-                            color = Color(200, 0, 0)
-                        }
-                    }
 
                     mangaList.size == 1 -> respond {
                         embeds.add(EmbedBuilder().mangaView(mangaList.first()))
                     }
 
-                    mangaList.size < 5 -> respond {
-                        embed {
-                            this.title = "Encontrados ${mangaList.size} resultados\n\n"
-                            description = filterDescription +
+                    mangaList.size < 5 -> respondWithSuccess(
+                            "Encontrados ${mangaList.size} resultados\n\n",
+                            filterDescription +
                                     mangaList.joinToString(prefix="\n", separator="\n") { "[#${it.id}] ${it.title}" }
-                            color = Color(0, 200, 0)
-                        }
-                    }
+                        )
 
                     else -> respondingPaginator {
                         val chunks = mangaList.chunked(5)
@@ -325,7 +319,7 @@ class MangaExtension: Extension(), KordExKoinComponent {
                                 this.title = "Encontrados ${mangaList.size} resultados\n\n"
                                 description = filterDescription +
                                         chunk.joinToString(prefix="\n", separator="\n") { "[#${it.id}] ${it.title}" }
-                                color = Color(0, 200, 0)
+                                color = colors.success
                             }
                         }
                     }.send()
@@ -345,8 +339,8 @@ class MangaExtension: Extension(), KordExKoinComponent {
 
                 when {
                     mangaList.isEmpty() -> respondWithInfo(
-                        "Sin resultados",
-                        "No se encontró nada similar a lo buscado"
+                        title="Sin resultados",
+                        description="No se encontró nada similar a lo buscado"
                     )
 
                     mangaList.size == 1 -> respond {
@@ -387,7 +381,7 @@ class MangaExtension: Extension(), KordExKoinComponent {
 
                 if (!validPpc) {
                     respondWithError(
-                        "Especifica la cantidad de páginas por capítulo o valores" +
+                        description="Especifica la cantidad de páginas por capítulo o valores" +
                                 " en otros argumentos que me permitan computarlo!"
                     )
                 } else try {
@@ -415,7 +409,7 @@ class MangaExtension: Extension(), KordExKoinComponent {
                         }
                     }
                 } catch (e: DownloadException) {
-                    respondWithError("Error al agregar")
+                    respondWithError(description="Error al agregar")
                 }
             }
         }

--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/MangaKog.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/MangaKog.kt
@@ -473,42 +473,15 @@ class MangaExtension: Extension(), KordExKoinComponent {
                             )
                         }
 
-                        respond {
-                            try {
-                                db.updateManga(mangaChanges, *flags.toTypedArray())
-                                kordLogger.info { "${user.id} edited entry #${mangaChanges.id} (${currentManga.title})" }
+                        try {
+                            db.updateManga(mangaChanges, *flags.toTypedArray())
+                            kordLogger.info { "${user.id} edited entry #${mangaChanges.id} (${currentManga.title})" }
 
-                                // TODO: move to Views
-                                embed {
-                                    title = "Editado [#${currentManga.id}] ${currentManga.title}"
-                                    color = Color(0, 200, 0)
+                            respondWithChanges(currentManga)
+                        } catch (e: DownloadException) {
+                            kordLogger.trace(e) { "Error downloading a cover from ${currentManga.imgURLSource}" }
 
-                                    description = "__Campos modificados__:\n\n" +
-                                            listOf<Pair<String, *>>(
-                                                ("Título" to arguments.title),
-                                                ("Descripción" to arguments.description),
-                                                ("Imagen" to arguments.image),
-                                                ("Link" to arguments.link),
-                                                ("Tomos" to arguments.volumes),
-                                                ("Páginas por capítulo" to arguments.pagesPerChapter),
-                                                ("Páginas por tomo" to arguments.pagesPerVolume),
-                                                ("Demografía" to arguments.demographic),
-                                                ("Tags (nuevos)" to arguments.addTags),
-                                                ("Tags (removidos)" to arguments.removeTags)
-                                            )
-                                                .filter { it.second != null }
-                                                .joinToString("\n") { it.first }
-                                }
-                            } catch (e: DownloadException) {
-                                kordLogger.trace(e) { "Error downloading a cover from ${currentManga.imgURLSource}" }
-
-                                embed {
-                                    title = "**Error**"
-                                    description = "Hubo un problema descargando la imagen"
-
-                                    color = Color(200, 0, 0)
-                                }
-                            }
+                            respondWithError("Hubo un problema descargando la imagen")
                         }
                     }
                 }

--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/Views.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/Views.kt
@@ -116,6 +116,28 @@ suspend fun PublicSlashCommandContext<MangaExtension.EditArguments, *>.respondWi
     }
 }
 
+suspend fun PublicSlashCommandContext<*, *>.respondWithInfo(title: String = "**Info**", description: String) {
+    respond {
+        embed {
+            this.title = title
+            this.description = description
+
+            color = Color(200, 100, 0)
+        }
+    }
+}
+
+suspend fun PublicSlashCommandContext<*, *>.respondWithSuccess(description: String) {
+    respond {
+        embed {
+            title = "**Éxito**"
+            this.description = description
+
+            color = Color(0, 200, 0)
+        }
+    }
+}
+
 suspend fun PublicSlashCommandContext<*, *>.respondWithError(description: String) {
     respond {
         embed {

--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/Views.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/Views.kt
@@ -2,13 +2,18 @@ package ar.pelotude.ohhsugoi.bot
 
 import ar.pelotude.ohhsugoi.db.MangaWithTags
 import com.kotlindiscord.kord.extensions.checks.types.CheckContext
+import com.kotlindiscord.kord.extensions.commands.application.slash.EphemeralSlashCommandContext
+import com.kotlindiscord.kord.extensions.commands.application.slash.PublicSlashCommandContext
 import com.kotlindiscord.kord.extensions.components.components
 import com.kotlindiscord.kord.extensions.components.ephemeralButton
 import com.kotlindiscord.kord.extensions.types.edit
+import com.kotlindiscord.kord.extensions.types.respond
+import dev.kord.common.Color
 import dev.kord.core.entity.User
 import dev.kord.core.event.interaction.ButtonInteractionCreateEvent
 import dev.kord.rest.builder.message.EmbedBuilder
 import dev.kord.rest.builder.message.create.FollowupMessageCreateBuilder
+import dev.kord.rest.builder.message.create.embed
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -82,6 +87,44 @@ fun EmbedBuilder.mangaView(manga: MangaWithTags): EmbedBuilder {
     }
 
     return this
+}
+
+suspend fun PublicSlashCommandContext<MangaExtension.EditArguments, *>.respondWithChanges(
+    previousManga: MangaWithTags
+) {
+    respond {
+        embed {
+            title = "Editado [#${previousManga.id}] ${previousManga.title}"
+            color = Color(0, 200, 0)
+
+            description = "__Campos modificados__:\n\n" +
+                    listOf<Pair<String, *>>(
+                        ("Título" to arguments.title),
+                        ("Descripción" to arguments.description),
+                        ("Imagen" to arguments.image),
+                        ("Link" to arguments.link),
+                        ("Tomos" to arguments.volumes),
+                        ("Páginas por capítulo" to arguments.pagesPerChapter),
+                        ("Páginas por tomo" to arguments.pagesPerVolume),
+                        ("Demografía" to arguments.demographic),
+                        ("Tags (nuevos)" to arguments.addTags),
+                        ("Tags (removidos)" to arguments.removeTags)
+                    )
+                        .filter { it.second != null }
+                        .joinToString("\n") { it.first }
+        }
+    }
+}
+
+suspend fun PublicSlashCommandContext<*, *>.respondWithError(description: String) {
+    respond {
+        embed {
+            title = "**Error**"
+            this.description = description
+
+            color = Color(200, 0, 0)
+        }
+    }
 }
 
 suspend fun FollowupMessageCreateBuilder.confirmationDialog(

--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/Views.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/Views.kt
@@ -21,6 +21,13 @@ import java.time.format.DateTimeFormatter
 import java.util.*
 import java.util.concurrent.atomic.AtomicBoolean
 
+object colors {
+    val info = Color (0, 0, 200)
+    val warning = Color(200, 100, 0)
+    val success = Color(0, 200, 0)
+    val error = Color(200, 0, 0)
+}
+
 val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern(
         "dd/MMMM/YYYY", Locale.forLanguageTag("es-ES")
 )
@@ -96,7 +103,7 @@ suspend fun PublicSlashCommandContext<MangaExtension.EditArguments, *>.respondWi
     respond {
         embed {
             title = "Editado [#${previousManga.id}] ${previousManga.title}"
-            color = Color(0, 200, 0)
+            color = colors.success
 
             description = "__Campos modificados__:\n\n" +
                     listOf<Pair<String, *>>(
@@ -125,7 +132,7 @@ suspend fun PublicSlashCommandContext<*, *>.respondWithInfo(title: String = "**I
             this.title = title
             this.description = description
 
-            color = Color(200, 100, 0)
+            color = colors.info
         }
     }
 }
@@ -136,7 +143,7 @@ suspend fun PublicSlashCommandContext<*, *>.respondWithSuccess(description: Stri
             title = "**Éxito**"
             this.description = description
 
-            color = Color(0, 200, 0)
+            color = colors.success
         }
     }
 }
@@ -147,7 +154,7 @@ suspend fun PublicSlashCommandContext<*, *>.respondWithError(description: String
             title = "**Error**"
             this.description = description
 
-            color = Color(200, 0, 0)
+            color = colors.error
         }
     }
 }

--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/Views.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/Views.kt
@@ -149,19 +149,19 @@ suspend fun PublicSlashCommandContext<*, *>.respondWithError(description: String
     }
 }
 
-suspend fun FollowupMessageCreateBuilder.confirmationDialog(
-        content: String,
-        actor: User,
-        cancel: (suspend () -> Any?)? = null,
-        confirm: suspend () -> Any?
-) {
+suspend fun PublicSlashCommandContext<*, *>.requestConfirmation(
+    content: String,
+    cancel: (suspend () -> Any?)? = null,
+    confirm: suspend () -> Any?,
+) = respond {
     this.content = content
     components {
         val done = AtomicBoolean()
+        val user = user.asUser()
 
         ephemeralButton {
             label = "Confirmar"
-            check { sameUser(actor) }
+            check { sameUser(user) }
 
             action {
                 if (!done.getAndSet(true)) {
@@ -174,7 +174,7 @@ suspend fun FollowupMessageCreateBuilder.confirmationDialog(
 
         ephemeralButton {
             label = "Cancelar"
-            check { sameUser(actor) }
+            check { sameUser(user) }
 
             action {
                 if (!done.getAndSet(true)) {

--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/Views.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/Views.kt
@@ -126,7 +126,7 @@ suspend fun PublicSlashCommandContext<MangaExtension.EditArguments, *>.respondWi
     }
 }
 
-suspend fun PublicSlashCommandContext<*, *>.respondWithInfo(title: String = "**Info**", description: String) {
+suspend fun PublicSlashCommandContext<*, *>.respondWithInfo(description: String, title: String = "**Info**") {
     respond {
         embed {
             this.title = title
@@ -137,10 +137,10 @@ suspend fun PublicSlashCommandContext<*, *>.respondWithInfo(title: String = "**I
     }
 }
 
-suspend fun PublicSlashCommandContext<*, *>.respondWithSuccess(description: String) {
+suspend fun PublicSlashCommandContext<*, *>.respondWithSuccess(description: String, title: String = "**Éxito**") {
     respond {
         embed {
-            title = "**Éxito**"
+            this.title = title
             this.description = description
 
             color = colors.success
@@ -148,10 +148,10 @@ suspend fun PublicSlashCommandContext<*, *>.respondWithSuccess(description: Stri
     }
 }
 
-suspend fun PublicSlashCommandContext<*, *>.respondWithError(description: String) {
+suspend fun PublicSlashCommandContext<*, *>.respondWithError(description: String, title: String = "**Error**") {
     respond {
         embed {
-            title = "**Error**"
+            this.title = title
             this.description = description
 
             color = colors.error

--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/db/MangaAPI.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/db/MangaAPI.kt
@@ -120,7 +120,7 @@ interface MangaDatabase {
         pagesPerChapter: Long? = null,
         tags: Set<String> = setOf(),
         read: Boolean = false,
-    ): Long
+    ): MangaWithTags
 
     /**
      * Updates a manga by applying changes onto its current data,

--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/db/MangaDatabase.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/db/MangaDatabase.kt
@@ -132,7 +132,7 @@ class MangaDatabaseSQLite(
         pagesPerChapter: Long?,
         tags: Set<String>,
         read: Boolean,
-    ): Long {
+    ): MangaWithTags {
         val insertionId = database.transactionWithResult {
             val mangaId = queries.insert(
                 title = title,
@@ -161,7 +161,7 @@ class MangaDatabaseSQLite(
             queries.updateMangaImgURL(imgFileName, insertionId)
         }
 
-        return insertionId
+        return queries.selectMangaWithTags(listOf(1), ::mangaSQLDmapper).executeAsOne()
     }
 
     override suspend fun updateManga(changes: MangaChanges, vararg flags: UpdateFlags) = withContext(dispatcher) {

--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/db/MangaDatabase.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/db/MangaDatabase.kt
@@ -149,15 +149,17 @@ class MangaDatabaseSQLite(
 
             addTags(mangaId, tags)
 
-            if (imgURLSource != null) {
-                val imgFileName = storeMangaCover(imgURLSource, mangaId)
-                queries.updateMangaImgURL(imgFileName, mangaId)
+            afterCommit {
+                kordLogger.info { "Inserted $title at $mangaId." }
             }
 
             mangaId
         }
 
-        kordLogger.info { "Inserted $title at $insertionId." }
+        if (imgURLSource != null) {
+            val imgFileName = storeMangaCover(imgURLSource, insertionId)
+            queries.updateMangaImgURL(imgFileName, insertionId)
+        }
 
         return insertionId
     }


### PR DESCRIPTION
- Embeds now can take some of the colors in `Colors`
-  `respondWith...` `...Error`|`...Info`|`...Success` embeds can now be used to respond with consistent style
- Cancelled confirmation requests are now destroyed
- Confirmation requests now are destroyed after a 15 seconds timeout
- Now information coming from the database is used to display a just-inserted entry (so we don't have to rely on the user's ephemeral embed to show the entries' thumbnails)
- Cleaned up some of the mess (there's still more to do)

Closes #30 