### PR TITLE
Image download & resizing tools

### DIFF
--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/MangaKog.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/MangaKog.kt
@@ -1,9 +1,9 @@
 package ar.pelotude.ohhsugoi.bot
 
-import ar.pelotude.ohhsugoi.UnsupportedDownloadException
+import ar.pelotude.ohhsugoi.util.image.UnsupportedDownloadException
 import ar.pelotude.ohhsugoi.db.*
-import ar.pelotude.ohhsugoi.isValidURL
-import ar.pelotude.ohhsugoi.makeTitle
+import ar.pelotude.ohhsugoi.util.isValidURL
+import ar.pelotude.ohhsugoi.util.makeTitle
 import com.kotlindiscord.kord.extensions.checks.hasRole
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.application.slash.converters.impl.optionalStringChoice

--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/MangaKog.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/MangaKog.kt
@@ -14,7 +14,6 @@ import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
 import com.kotlindiscord.kord.extensions.koin.KordExKoinComponent
 import com.kotlindiscord.kord.extensions.types.respond
 import com.kotlindiscord.kord.extensions.types.respondingPaginator
-import dev.kord.common.Color
 import dev.kord.core.entity.Attachment
 import dev.kord.core.kordLogger
 import dev.kord.rest.builder.message.EmbedBuilder
@@ -403,6 +402,8 @@ class MangaExtension: Extension(), KordExKoinComponent {
                         read = false
                     )
 
+                    kordLogger.info { "${user.id} added entry #${insertedManga.id} (${insertedManga.title})" }
+
                     respond {
                         content = "Agregado exitosamente."
 
@@ -477,10 +478,13 @@ class MangaExtension: Extension(), KordExKoinComponent {
                         kordLogger.info { "${user.id} edited entry #${mangaChanges.id} (${currentManga.title})" }
 
                         respondWithChanges(currentManga)
-                    } catch (e: DownloadException) {
-                        kordLogger.trace(e) { "Error downloading a cover from ${currentManga.imgURLSource}" }
-
-                        respondWithError("Hubo un problema descargando la imagen")
+                    } catch (e: UnsupportedDownloadException) {
+                        respondWithError(
+                            description="Ese tipo de imagen no es válido." +
+                                    " Prueba con una imagen más pequeña y en JPG o PNG."
+                        )
+                    } catch (e: IOException) {
+                        respondWithError(description="Error al intentar descargar la imagen.")
                     }
                 }
             }

--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/MangaKog.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/bot/MangaKog.kt
@@ -1,5 +1,6 @@
 package ar.pelotude.ohhsugoi.bot
 
+import ar.pelotude.ohhsugoi.UnsupportedDownloadException
 import ar.pelotude.ohhsugoi.db.*
 import ar.pelotude.ohhsugoi.isValidURL
 import ar.pelotude.ohhsugoi.makeTitle
@@ -19,6 +20,7 @@ import dev.kord.core.kordLogger
 import dev.kord.rest.builder.message.EmbedBuilder
 import dev.kord.rest.builder.message.create.embed
 import org.koin.core.component.inject
+import java.io.IOException
 import java.net.URL
 
 class MangaExtension: Extension(), KordExKoinComponent {
@@ -408,8 +410,13 @@ class MangaExtension: Extension(), KordExKoinComponent {
                             mangaView(insertedManga)
                         }
                     }
-                } catch (e: DownloadException) {
-                    respondWithError(description="Error al agregar")
+                } catch (e: UnsupportedDownloadException) {
+                    respondWithError(
+                        description="Ese tipo de imagen no es válido." +
+                            " Prueba con una imagen más pequeña y en JPG o PNG."
+                    )
+                } catch (e: IOException) {
+                    respondWithError(description="Error al intentar descargar la imagen.")
                 }
             }
         }

--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/db/MangaAPI.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/db/MangaAPI.kt
@@ -148,5 +148,3 @@ enum class UpdateFlags {
     UNSET_CHAPTERS,
     UNSET_PPC,
 }
-
-class DownloadException(message: String, cause: Throwable) : IOException(message, cause)

--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/db/MangaDatabase.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/db/MangaDatabase.kt
@@ -5,6 +5,10 @@ import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import ar.pelotude.Database
 import ar.pelotude.ohhsugoi.*
+import ar.pelotude.ohhsugoi.util.image.downloadImage
+import ar.pelotude.ohhsugoi.util.makeTitle
+import ar.pelotude.ohhsugoi.util.image.saveAsJpg
+import ar.pelotude.ohhsugoi.util.uuidString
 import com.kotlindiscord.kord.extensions.koin.KordExKoinComponent
 import dev.kord.core.kordLogger
 import kotlinx.coroutines.CoroutineDispatcher

--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/db/MangaDatabase.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/db/MangaDatabase.kt
@@ -91,19 +91,19 @@ class MangaDatabaseSQLite(
      * @param[mangaId] The id of the manga that the image represents
      * @return A [String] containing filename of the downloaded image,
      * or null if the file couldn't be downloaded
-     * @throws DownloadException if an I/O error occurs when downloading the image
+     *
+     * @throws IOException if an I/O error occurs when downloading the image
+     * @throws UnsupportedDownloadException if the image file or its content is not supported
      */
     private suspend fun storeMangaCover(imgSource: URL, mangaId: Long): String {
         imgStoreSemaphore.withPermit {
             val mangaFileName = "$mangaId-${uuidString()}.jpg"
             val destiny = dbConfig.mangaImageDirectory / mangaFileName
 
-            try {
-                downloadImage(imgSource, dbConfig.mangaCoversWidth, dbConfig.mangaCoversHeight)
-                    .saveAsJpg(destiny.toFile(), 0.85f)
-            } catch(e: IOException) {
-                throw DownloadException("The image could not be downloaded", e)
-            }
+            /** throws [IOException] and [UnsupportedDownloadException] */
+            downloadImage(imgSource, dbConfig.mangaCoversWidth, dbConfig.mangaCoversHeight)
+                .saveAsJpg(destiny.toFile(), 0.85f)
+
             kordLogger.info { "Added image: $mangaFileName" }
 
             return mangaFileName

--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/db/MangaDatabase.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/db/MangaDatabase.kt
@@ -4,14 +4,13 @@ import app.cash.sqldelight.TransactionCallbacks
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import ar.pelotude.Database
-import ar.pelotude.ohhsugoi.downloadMangaCover
-import ar.pelotude.ohhsugoi.makeTitle
-import ar.pelotude.ohhsugoi.saveAsJpg
-import ar.pelotude.ohhsugoi.uuidString
+import ar.pelotude.ohhsugoi.*
 import com.kotlindiscord.kord.extensions.koin.KordExKoinComponent
 import dev.kord.core.kordLogger
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import org.koin.core.component.inject
 import java.io.IOException
@@ -22,6 +21,7 @@ class MangaDatabaseSQLite(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : MangaDatabase, KordExKoinComponent {
     internal val dbConfig: DatabaseConfiguration by inject()
+
     private val driver: SqlDriver = JdbcSqliteDriver("jdbc:sqlite:${dbConfig.sqlitePath}")
 
     private val database: Database = Database.Schema.run {
@@ -43,7 +43,10 @@ class MangaDatabaseSQLite(
 
         return@run Database(driver)
     }
+
     private val queries = database.mangaQueries
+
+    private val imgStoreSemaphore = Semaphore(3)
 
     override suspend fun getManga(id: Long): MangaWithTags? {
         return withContext(dispatcher) {
@@ -79,8 +82,8 @@ class MangaDatabaseSQLite(
     }
 
     /**
-     * Downloads the content from a [URL], assuming in the process
-     * it's an image file, then randomizes a name for it based on [mangaId]
+     * Downloads the content from a [URL], assuming  it's an image file,
+     * then randomizes a name for it based on [mangaId]
      * with the prefix "$[mangaId]-". The image is stored in the directory
      * specified by the configuration.
      *
@@ -90,19 +93,21 @@ class MangaDatabaseSQLite(
      * or null if the file couldn't be downloaded
      * @throws DownloadException if an I/O error occurs when downloading the image
      */
-    private fun storeMangaCover(imgSource: URL, mangaId: Long): String {
-        val mangaFileName = "$mangaId-${uuidString()}.jpg"
-        val destiny = dbConfig.mangaImageDirectory / mangaFileName
+    private suspend fun storeMangaCover(imgSource: URL, mangaId: Long): String {
+        imgStoreSemaphore.withPermit {
+            val mangaFileName = "$mangaId-${uuidString()}.jpg"
+            val destiny = dbConfig.mangaImageDirectory / mangaFileName
 
-        try {
-            downloadMangaCover(imgSource, dbConfig.mangaCoversWidth, dbConfig.mangaCoversHeight)
-                    .saveAsJpg(destiny.toFile())
-        } catch(e: IOException) {
-            throw DownloadException("The image could not be downloaded", e)
+            try {
+                downloadImage(imgSource, dbConfig.mangaCoversWidth, dbConfig.mangaCoversHeight)
+                    .saveAsJpg(destiny.toFile(), 0.85f)
+            } catch(e: IOException) {
+                throw DownloadException("The image could not be downloaded", e)
+            }
+            kordLogger.info { "Added image: $mangaFileName" }
+
+            return mangaFileName
         }
-        kordLogger.info { "Added image: $mangaFileName " }
-
-        return mangaFileName
     }
 
     /**
@@ -166,7 +171,7 @@ class MangaDatabaseSQLite(
 
     override suspend fun updateManga(changes: MangaChanges, vararg flags: UpdateFlags) = withContext(dispatcher) {
         val mangaId = changes.id
-        
+
         val imgFilePath = if (changes.imgURLSource != null) {
             // throws DownloadException
             storeMangaCover(changes.imgURLSource, mangaId)

--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/util/Utils.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/util/Utils.kt
@@ -1,0 +1,28 @@
+package ar.pelotude.ohhsugoi.util
+
+import java.net.URL
+import java.util.*
+
+/** This isn't ideal but I'm not gonna add another dependency or write something fancy
+ * for something meant to be used among trustworthy people */
+fun String.isValidURL() = try {
+    URL(this).toURI()
+    true
+} catch(e: java.net.MalformedURLException) {
+    false
+}
+
+fun randomString(length: Int): String {
+    val characters = ('a'..'z') + ('A'..'Z') + ('0'..'9')
+
+    return (0..length).map {
+        characters.random()
+    }.joinToString("")
+}
+
+fun uuidString() = UUID.randomUUID().toString()
+
+fun String.capitalize() = this.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
+
+/** But like in "This is a title", not "This Is A Title" */
+fun String.makeTitle() = this.lowercase().capitalize()

--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/util/image/ImageExceptions.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/util/image/ImageExceptions.kt
@@ -1,0 +1,12 @@
+package ar.pelotude.ohhsugoi.util.image
+
+enum class DownloadErrorType {
+    DIMENSIONS_EXCEEDED,
+    UNSUPPORTED_FORMAT,
+}
+
+class UnsupportedDownloadException(
+    message: String?,
+    cause: Throwable? = null,
+    code: DownloadErrorType,
+) : Exception(message, cause)

--- a/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/util/image/ImageUtils.kt
+++ b/sheska/src/main/kotlin/ar/pelotude/ohhsugoi/util/image/ImageUtils.kt
@@ -1,48 +1,12 @@
-package ar.pelotude.ohhsugoi
+package ar.pelotude.ohhsugoi.util.image
 
 import java.awt.image.BufferedImage
 import java.io.File
 import java.net.URL
-import java.util.*
 import javax.imageio.IIOImage
 import javax.imageio.ImageIO
 import javax.imageio.ImageWriteParam
 import javax.imageio.stream.FileImageOutputStream
-
-/** This isn't ideal but I'm not gonna add another dependency or write something fancy
- * for something meant to be used among trustworthy people */
-fun String.isValidURL() = try {
-    URL(this).toURI()
-    true
-} catch(e: java.net.MalformedURLException) {
-    false
-}
-
-fun randomString(length: Int): String {
-    val characters = ('a'..'z') + ('A'..'Z') + ('0'..'9')
-
-    return (0..length).map {
-        characters.random()
-    }.joinToString("")
-}
-
-fun uuidString() = UUID.randomUUID().toString()
-
-fun String.capitalize() = this.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
-
-/** But like in "This is a title", not "This Is A Title" */
-fun String.makeTitle() = this.lowercase().capitalize()
-
-enum class DownloadErrorType {
-    DIMENSIONS_EXCEEDED,
-    UNSUPPORTED_FORMAT,
-}
-
-class UnsupportedDownloadException(
-    message: String?,
-    cause: Throwable? = null,
-    code: DownloadErrorType,
-) : Exception(message, cause)
 
 /**
  * Synchronous function to download an image with
@@ -72,7 +36,10 @@ fun downloadImage(
         ImageIO.createImageInputStream(stream).use { imgStream ->
             val reader = ImageIO.getImageReaders(imgStream).let {
                 if (it.hasNext()) it.next()
-                else throw UnsupportedDownloadException("Format not supported", code=DownloadErrorType.UNSUPPORTED_FORMAT)
+                else throw UnsupportedDownloadException(
+                    "Format not supported",
+                    code = DownloadErrorType.UNSUPPORTED_FORMAT
+                )
             }
 
             reader.input = imgStream
@@ -80,7 +47,7 @@ fun downloadImage(
             val (width, height) = (reader.getWidth(0) to reader.getHeight(0))
 
             if (width * height > 3000 * 4000) {
-                throw UnsupportedDownloadException("The image is too big", code=DownloadErrorType.DIMENSIONS_EXCEEDED)
+                throw UnsupportedDownloadException("The image is too big", code = DownloadErrorType.DIMENSIONS_EXCEEDED)
             }
 
             // we check if we must make it fit horizontally, vertically or neither, and by how much...


### PR DESCRIPTION
The new `UnsupportedDownloadException` is meant to be used in case of errors found during the image processing, except the underlying IO operations to reach the URL (hence if a stream to the URL can't be established, it will thrown an `IOException`.)

This class also provides error codes in the form of an enum class, `DownloadErrorType`. As of right now, two codes are defined: one used in case an image is too big for Sheska to handle, and another one in case the image file isn't supported at all by `ImageIO`.